### PR TITLE
Adds command marshalling between react-native and web

### DIFF
--- a/src/util/mv2-rn.js
+++ b/src/util/mv2-rn.js
@@ -11,18 +11,13 @@ class Marty2 {
         this.power = 0;
         this.servos = 0;
         this.accel = 0;
-        this.savedProjectStates = {
-            '0': '',
-            '1': '',
-            '2': '',
-            '3': '',
-            '4': '',
-            '5': '',
-            '6': '',
-            '7': '',
-            '8': '',
-            '9': ''
-        };
+        this.commandPromise = null;
+        this.onCommandReply = this.onCommandReply.bind(this);
+        this.sendCommand = this.sendCommand.bind(this);
+        this.saveScratchFile = this.saveScratchFile.bind(this);
+        this.loadScratchFile = this.loadScratchFile.bind(this);
+        this.listSavedScratchFiles = this.listSavedScratchFiles.bind(this);
+        this.deleteScratchFile = this.deleteScratchFile.bind(this);
     }
 
     // eslint-disable-next-line camelcase
@@ -48,6 +43,82 @@ class Marty2 {
         } catch (err) {
             // eslint-disable-next-line no-console
             console.log(`Error sending to react native: ${err}`);
+        }
+    }
+
+    /**
+     * Save a scratch file
+     * @param string fileName Filename
+     * @param string contents Base64 data URL
+     */
+    saveScratchFile(fileName, contents) {
+        return this.sendCommand({
+            command: 'saveFile',
+            fileName,
+            contents
+        });
+    }
+
+    /**
+     * Delete a saved scratch file
+     * @param string fileName File to delete
+     */
+    deleteScratchFile(fileName) {
+        return this.sendCommand({
+            command: 'deleteFile',
+            fileName,
+        });
+    }
+
+    /**
+     * Load a scratch file
+     * @param string fileName File to load
+     */
+    loadScratchFile(fileName) {
+        return this.sendCommand({
+            command: 'loadFile',
+            fileName,
+        });
+    }
+
+    /**
+     * List the saved scratch files
+     */
+    listSavedScratchFiles() {
+        return this.sendCommand({
+            command: 'listFiles'
+        });
+    }
+
+    /**
+     * Sends a command to the react-native code and returns a promise that will be fulfilled when the react-native code replies
+     * @param {command: string} payload Payload to send to the react-native code
+     */
+    sendCommand(payload) {
+        if (this.commandPromise) {
+            console.warn("Command already in flight");
+        }
+        const promise = new Promise((resolve, reject) => {
+            this.commandPromise = { resolve, reject };
+        });
+        window.ReactNativeWebView.postMessage(JSON.stringify(payload));
+        return promise;
+    }
+
+    /**
+     * Called by the react-native code to respond to sendCommand
+     * @param {success: boolean, error?: string} args Response from the react native side
+     */
+    onCommandReply(args) {
+        if (this.commandPromise) {
+            if (args.success) {
+                this.commandPromise.resolve(args);
+            } else {
+                this.commandPromise.reject(new Error(args.error));
+            }
+            this.commandPromise = null;
+        } else {
+            console.warn("Unhandled command reply");
         }
     }
 


### PR DESCRIPTION
### Resolves

This replaces the current saving and loading of scratch files with specific commands for save, load, delete and list files.

### Proposed Changes

The communication between the web browser and the react-native side is now 2 way.
 
### Reason for Changes

Change to use filenames for saving and improve the robustness of the code.

### Test Coverage

NA
