### PR TITLE
Wifi-scratch add-on

### DIFF
--- a/src/util/mv2-rn.js
+++ b/src/util/mv2-rn.js
@@ -69,6 +69,7 @@ class Marty2 extends EventDispatcher {
         this.isInApp = false;
         this._martyConnector = new marty2js.Marty();
         this._martyConnector.setEventListener(this);
+
     }
 
     isWorkingInApp() {
@@ -280,6 +281,21 @@ class Marty2 extends EventDispatcher {
         }
     }
 
+    getHWElemList(){
+        try {
+            return this.addons;
+        } catch (error) {
+            console.log('eventConnect - failed to get HWElems ' + error);
+            return null;
+        }
+        
+    }
+
+    convertHWElemType(whoAmITypeCode){
+        return this._martyConnector.convertHWElemType(whoAmITypeCode);
+    }
+
+
     onRxSmartServo(smartServos) {
         // console.log(`servo`, smartServos);
         this.servos = JSON.stringify(smartServos);
@@ -297,7 +313,8 @@ class Marty2 extends EventDispatcher {
 
     onRxAddOnPub(addOnInfo) {
         this.addons = JSON.stringify(addOnInfo);
-        // console.log(`addOn`);
+        // console.log('mv2-rn this.addons');
+        // console.log(this.addons);
     }
 }
 


### PR DESCRIPTION
This PR updates the base scratch3-vm wifi-scratch code with the following:

- Add-on management for the inventor set
- Add-on management for the v2 IR sens
- Add-on list displayed in the Connectivity tab (currently connected add-ons)

**Note:** Base branch is wifi-scratch as we don't want to merge this code with the mobile app code just yet.