### PR TITLE
Work with batch 2 robot color sensor names

### DIFF
--- a/src/blocks/scratch3_mv2.js
+++ b/src/blocks/scratch3_mv2.js
@@ -755,12 +755,12 @@ class Scratch3Mv2Blocks {
         return mv2.battRemainCapacityPercent;
     }
 
+    // TODO: redo the obsctacle sense (and other sensor blocks) to use names of actual connected addons from dynamically populated list
     obstacleSense (args, util) {
         const addons = JSON.parse(mv2.addons).addons;
 
-        // if ir sensor not found we will check for colour sensor
-        let colourSensorName = "LeftColourSensorTouch";
-        if (args.SENSORCHOICE.includes("Right")){ colourSensorName = "RightColourSensorTouch"; }
+        // if ir sensor not found we will check for colour sensor with the same side in its name
+        const side = args.SENSORCHOICE.includes("Right") ? "Right" : "Left";
 
         let colourSensorVal = null;
         for (var i=0; i < addons.length; i++){
@@ -768,9 +768,10 @@ class Scratch3Mv2Blocks {
                 //mv2.send_REST('return val: ' + addons[i].vals[args.SENSORCHOICE]);
                 return addons[i].vals[args.SENSORCHOICE];
             }
-            if (colourSensorName in addons[i].vals){
-                colourSensorVal = addons[i].vals[colourSensorName];
+            if (addons[i].deviceTypeID == MV2_DTID_COLOUR && addons[i].name.includes(side)){
+                colourSensorVal = addons[i].vals[addons[i].name + 'Touch']
             }
+
         }
         if (colourSensorVal !== null) return colourSensorVal;
         return false;
@@ -778,9 +779,8 @@ class Scratch3Mv2Blocks {
 
     groundSense (args, util) {
         const addons = JSON.parse(mv2.addons).addons;
-        // if ir sensor not found we will check for colour sensor
-        let colourSensorName = "LeftColourSensorAir";
-        if (args.SENSORCHOICE.includes("Right")){ colourSensorName = "RightColourSensorAir"; }
+        // if ir sensor not found we will check for colour sensor with the same side in its name
+        const side = args.SENSORCHOICE.includes("Right") ? "Right" : "Left";
 
         let colourSensorVal = null;
         for (var i=0; i < addons.length; i++){
@@ -789,8 +789,8 @@ class Scratch3Mv2Blocks {
                 // sensor tells you if if the foot is in the air
                 return !addons[i].vals[args.SENSORCHOICE];
             }
-            if (colourSensorName in addons[i].vals){
-                colourSensorVal = !addons[i].vals[colourSensorName];
+            if (addons[i].deviceTypeID == MV2_DTID_COLOUR && addons[i].name.includes(side)){
+                colourSensorVal = !addons[i].vals[addons[i].name + 'Air']
             }
         }
         if (colourSensorVal !== null) return colourSensorVal;


### PR DESCRIPTION
This PR is a largely a sticking plaster, since the sensor and addon blocks should move to using dynamically populated menus of actually connected addons, rather than relying on preset names

### Resolves

This PR makes the obstacle and ground sensing blocks work with color sensors regardless of whether they're named colour or color.

### Proposed Changes

Identify whether user has selected a Left or Right obstacle/ground sensor
If a colour sensor with "Left" or "Right"  (as appropriate) in the name is found, get the reading from the obstacle/ground sensor there
If an IR sensor isn't found, return the value from the colour sensor


### Reason for Changes

In an effort to be more international, the batch 2 robots have their color sensors named "LeftColorSensor" by default, rather than "LeftColourSensor". These currently won't work with the obstacle and ground sensing blocks, which are hard coded to expect the colour sensors to be called "LeftColourSensor" and "RightColourSensor"

### Test Coverage

Tested on a batch 2 robot with new sensors, with scratch running in the app
