### PR TITLE
Bugfix/colour sensing calibrated hue

### DIFF
--- a/src/blocks/scratch3_mv2.js
+++ b/src/blocks/scratch3_mv2.js
@@ -798,6 +798,22 @@ class Scratch3Mv2Blocks {
         return false;
     }
 
+    getHueChroma(r, g, b){
+        const maxVal = Math.max(r, g, b);
+        const minVal = Math.min(r, g, b);
+        const chroma = maxVal - minVal;
+        let hue = 0;
+        if (r > g && r > b){
+            hue = (((g-b)/chroma)%6) * 60;
+        } else if (g > b){
+            hue = (((b-r)/chroma) + 2) * 60;
+        } else {
+            hue = (((r-g)/chroma) + 4) * 60;
+        }
+        if (hue < 0) hue += 360;
+        return [hue, chroma];
+    }
+
     colourSense (args, util) {
         const addons = JSON.parse(mv2.addons).addons;
         let csID = -1, selectedID = -1;
@@ -822,27 +838,25 @@ class Scratch3Mv2Blocks {
             return "air";
         } else {
             //mv2.send_REST('return val: ' + addons[i].vals[args.SENSORCHOICE]);
-            let red = addons[selectedID].vals[sensorname + "Red"];
-            let green = addons[selectedID].vals[sensorname + "Green"];
-            let blue = addons[selectedID].vals[sensorname + "Blue"];
-            let clear = addons[selectedID].vals[sensorname + "Clear"];
-            let maxVal = Math.max(red, green, blue);
-            red /= maxVal;
-            green /= maxVal;
-            blue /= maxVal;
+            const red = addons[selectedID].vals[sensorname + "Red"];
+            const green = addons[selectedID].vals[sensorname + "Green"];
+            const blue = addons[selectedID].vals[sensorname + "Blue"];
+            const clear = addons[selectedID].vals[sensorname + "Clear"];
+
             const colours = [
-                {red: [0.3, 0.75], green: [0.85, 1], blue: [0.6, 1.0], clear: [40, 150], name: "green"},
-                {red: [0.8, 1],  green: [0.3, 0.5], blue: [0.4, 0.77], clear: [40, 150], name: "red"},
-                {red: [0.3, 0.55], green: [0.37, 0.62], blue: [0.8, 1], clear: [40, 150], name: "purple"},
-                {red: [0.85, 1], green: [0.8, 1], blue: [0.45, 0.93], clear: [150, 255],name: "yellow"},
-                {red: [0.1, 0.25], green: [0.4, 0.75], blue: [0.8, 1], clear: [100, 255], name: "blue"},
-                {red: [0.75, 1], green: [0.6, 0.85], blue: [0.8, 1.0], clear: [110, 210], name: "pink"} 
+                {hue: [0, 10],    chroma: [100, 175], clear: [40, 150],  name: "red"},
+                {hue: [20, 50],   chroma: [150, 300], clear: [100, 255], name: "yellow"},
+                {hue: [100, 145], chroma: [10, 100],  clear: [40, 150],  name: "green"},
+                {hue: [190, 220], chroma: [95, 230],  clear: [90, 255],  name: "blue"},
+                {hue: [250, 280], chroma: [10, 50],   clear: [40, 150],  name: "purple"},
+                {hue: [345, 361], chroma: [100, 200], clear: [40, 150],  name: "red"}
             ];
-            //mv2.send_REST("red: " + red + " | green: " + green + " | blue: " + blue);
-            for (var i=0; i<colours.length; i++){
-                if ((colours[i].red[0] <= red && red <= colours[i].red[1]) && 
-                    (colours[i].green[0] <= green && green <= colours[i].green[1]) &&
-                    (colours[i].blue[0] <= blue && blue <= colours[i].blue[1]) &&
+
+            const [hue, chroma] = this.getHueChroma(red, green, blue);
+            //mv2.send_REST(`hue: ${hue}, chroma: ${chroma}, clear: ${clear} | RGB: ${red} ${green} ${blue}`);
+            for (let i=0; i<colours.length; i++){
+                if ((colours[i].hue[0] <= hue && hue <= colours[i].hue[1]) &&
+                    (colours[i].chroma[0] <= chroma && chroma <= colours[i].chroma[1]) &&
                     (colours[i].clear[0] <= clear && clear <= colours[i].clear[1])){
                         return colours[i].name;
                     }

--- a/src/blocks/scratch3_mv2.js
+++ b/src/blocks/scratch3_mv2.js
@@ -755,12 +755,12 @@ class Scratch3Mv2Blocks {
         return mv2.battRemainCapacityPercent;
     }
 
+    // TODO: redo the obsctacle sense (and other sensor blocks) to use names of actual connected addons from dynamically populated list
     obstacleSense (args, util) {
         const addons = JSON.parse(mv2.addons).addons;
 
-        // if ir sensor not found we will check for colour sensor
-        let colourSensorName = "LeftColourSensorTouch";
-        if (args.SENSORCHOICE.includes("Right")){ colourSensorName = "RightColourSensorTouch"; }
+        // if ir sensor not found we will check for colour sensor with the same side in its name
+        const side = args.SENSORCHOICE.includes("Right") ? "Right" : "Left";
 
         let colourSensorVal = null;
         for (var i=0; i < addons.length; i++){
@@ -768,9 +768,10 @@ class Scratch3Mv2Blocks {
                 //mv2.send_REST('return val: ' + addons[i].vals[args.SENSORCHOICE]);
                 return addons[i].vals[args.SENSORCHOICE];
             }
-            if (colourSensorName in addons[i].vals){
-                colourSensorVal = addons[i].vals[colourSensorName];
+            if (addons[i].deviceTypeID == MV2_DTID_COLOUR && addons[i].name.includes(side)){
+                colourSensorVal = addons[i].vals[addons[i].name + 'Touch']
             }
+
         }
         if (colourSensorVal !== null) return colourSensorVal;
         return false;
@@ -778,9 +779,8 @@ class Scratch3Mv2Blocks {
 
     groundSense (args, util) {
         const addons = JSON.parse(mv2.addons).addons;
-        // if ir sensor not found we will check for colour sensor
-        let colourSensorName = "LeftColourSensorAir";
-        if (args.SENSORCHOICE.includes("Right")){ colourSensorName = "RightColourSensorAir"; }
+        // if ir sensor not found we will check for colour sensor with the same side in its name
+        const side = args.SENSORCHOICE.includes("Right") ? "Right" : "Left";
 
         let colourSensorVal = null;
         for (var i=0; i < addons.length; i++){
@@ -789,8 +789,8 @@ class Scratch3Mv2Blocks {
                 // sensor tells you if if the foot is in the air
                 return !addons[i].vals[args.SENSORCHOICE];
             }
-            if (colourSensorName in addons[i].vals){
-                colourSensorVal = !addons[i].vals[colourSensorName];
+            if (addons[i].deviceTypeID == MV2_DTID_COLOUR && addons[i].name.includes(side)){
+                colourSensorVal = !addons[i].vals[addons[i].name + 'Air']
             }
         }
         if (colourSensorVal !== null) return colourSensorVal;


### PR DESCRIPTION
Should be merged after https://github.com/robotical/scratch3-vm/pull/21

### Resolves

Part of general update to use calibrated colour sensor values. Converts RGB to hue and chroma, as is also done by screen-free now

### Reason for Changes

The app will now be sending calibrated colour sensor values, since there is a lot of variation especially between batch 1 and batch 2 colour sensors. These changes remove some normalisation of values done in scratch, and move to what is hopefully a more robust way of detecting colour in general

### Test Coverage

Tested on a batch 1 and batch 2 robot
