### PR TITLE
M20-1073 Adjust wiggle timing to match new trajectory default

### DIFF
--- a/src/blocks/scratch3_mv2.js
+++ b/src/blocks/scratch3_mv2.js
@@ -432,7 +432,7 @@ class Scratch3Mv2Blocks {
     }
 
     wiggle (args, util) {
-        const moveTime = 5000;
+        const moveTime = 4000;
         console.log(`traj/wiggle/1/?moveTime=${moveTime}`);
         mv2.send_REST(`traj/wiggle/1/?moveTime=${moveTime}`);
         return new Promise(resolve =>


### PR DESCRIPTION
### Resolves

https://robotical.atlassian.net/browse/M20-1073

### Proposed Changes

As part of the wiggle timing fix, the default time for the movement has been changed to 4s. See https://github.com/robotical/RIC2FirmwareIDF/pull/160

### Reason for Changes

Sets the wiggle movement time as commanded by scratch to match the default in firmware, this will result in better movement

### Test Coverage

Checked on both the old and new versions of the wiggle trajectory. The change from 5s->4s doesn't significantly affect the performance on robots with older firmware, while improving performance for robots with the newer trajectory
